### PR TITLE
Change namespace of gmwm

### DIFF
--- a/R/mgmwm.R
+++ b/R/mgmwm.R
@@ -249,7 +249,7 @@ mgmwm = function(mimu, model = NULL, CI = FALSE, alpha_ci = NULL, n_boot_ci_max 
       }
 
       # Compute the parameter value from gmwm
-      uni_gmwm = gmwm::gmwm(model, data, model.type = 'imu')[[1]]
+      uni_gmwm = simts::gmwm(model, data, model.type = 'imu')[[1]]
 
       # Store the univariate gmwm
       param_starting[i,] = uni_gmwm


### PR DESCRIPTION
I had an issue with gmwm version 3.0.0 and mgmwm version 0.1.0. To solved it, I had to change gmwm namespace from gmwm to simts.